### PR TITLE
GBTP-761: Fix Lektor markdown extra spaces

### DIFF
--- a/lektor_tinymce.py
+++ b/lektor_tinymce.py
@@ -18,6 +18,9 @@ TEMPLATE = '''
     (new MutationObserver(function() {
         [...document.getElementsByTagName('textarea')].forEach(txt_elem => {
             if (txt_elem.classList.contains('form-control')) {
+                if(txt_elem.previousElementSibling.classList.contains('text-widget__replica')) {
+                    txt_elem.previousElementSibling.style.display = "none";
+                }
                 txt_elem.classList.add('tinymce-attached');
                 tinymce.init({
                     target: txt_elem,


### PR DESCRIPTION
[GBTP-761](https://spherical.atlassian.net/browse/GBTP-761)

In [this commit](https://github.com/lektor/lektor/commit/514eed4fb0152a2f1b0c111ffe9e7b2aa35f23db) Lektor added an extra fake div before all textareas to make them autogrow according to text content. Lektor-tinymce plugin adds tinymce div instead of textarea, so this fake div remains visible on the screen.
![image](https://github.com/sphericalpm/lektor-tinymce/assets/10845300/6fc0309f-7384-480f-a83f-e1196d6f8408)
![image](https://github.com/sphericalpm/lektor-tinymce/assets/10845300/6a6eb62f-e8d2-4095-8111-fa808eecf612)

This commit adds "display: none" to 'text-widget__replica' rather than original "visibility: none"

[GBTP-761]: https://spherical.atlassian.net/browse/GBTP-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ